### PR TITLE
Include engine routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Rails.application.routes.draw do
 end
 ```
 
+## Configuring namespaced engine routes
+
+```
+# config/initializers/rails_routes_api_engine.rb
+RailsRoutesApiEngine.configure do |config|
+  config.engines_names = [EngineClass]
+end
+```
+
 ## Contributing
 Contribution directions go here.
 

--- a/app/services/route_data_service.rb
+++ b/app/services/route_data_service.rb
@@ -5,14 +5,31 @@
 #     - controller
 module RouteDataService
   def self.get_routes_data
-    Rails.application.routes.routes.select do |route|
+    main_app_routes = format_routes(Rails.application.routes.routes)
+
+    engines = RailsRoutesApiEngine.configuration.engines || []
+    engines_routes = engines.map do |engine|
+      format_routes(engine::Engine.routes.routes, engine)
+    end.flatten
+
+    main_app_routes + engines_routes
+  end
+
+  def self.format_routes(routes, engine = nil)
+    routes.select do |route|
       !route.defaults[:internal]
     end.map do |route|
       {
-        path: route.path.spec.to_s,
+        path: "#{engine_route_prefix(engine)}#{route.path.spec.to_s}",
         action: route.defaults[:action],
         controller: route.defaults[:controller]
       }
     end
+  end
+
+  def self.engine_route_prefix(engine)
+    return "" unless engine
+
+    "/#{engine.to_s.underscore}"
   end
 end

--- a/app/services/route_data_service.rb
+++ b/app/services/route_data_service.rb
@@ -8,9 +8,9 @@ module RouteDataService
     main_app_routes = format_routes(Rails.application.routes.routes)
 
     engines = RailsRoutesApiEngine.configuration.engines || []
-    engines_routes = engines.map do |engine|
+    engines_routes = engines.flat_map do |engine|
       format_routes(engine::Engine.routes.routes, engine)
-    end.flatten
+    end
 
     main_app_routes + engines_routes
   end

--- a/lib/rails_routes_api_engine.rb
+++ b/lib/rails_routes_api_engine.rb
@@ -1,5 +1,11 @@
 require "rails_routes_api_engine/engine"
 
 module RailsRoutesApiEngine
-  # Your code goes here...
+  def self.configuration
+    @configuration ||= OpenStruct.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
 end

--- a/lib/rails_routes_api_engine/version.rb
+++ b/lib/rails_routes_api_engine/version.rb
@@ -1,3 +1,3 @@
 module RailsRoutesApiEngine
-  VERSION = '0.4.0'
+  VERSION = '0.5.2'
 end

--- a/lib/rails_routes_api_engine/version.rb
+++ b/lib/rails_routes_api_engine/version.rb
@@ -1,3 +1,3 @@
 module RailsRoutesApiEngine
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end


### PR DESCRIPTION
We have an engine called **Decision** in **UA**, and it has routes that should be included here, but it only gets main application routes. ([this line](https://github.com/ForwardFinancing/rails_routes_api_engine/blob/master/app/services/route_data_service.rb#L8))

I added a **Configuration** pattern so APPs using **rails_routes_api_engine** can inform engines' routes to be included.

# Testing

In **UA** I created this initializer:

```ruby 
RailsRoutesApiEngine.configure do |config|
  config.engines = [Decision]
end
```

Now we can allow **Decision** Engine routes on Auth:

![Screenshot 2025-02-05 at 18 58 09](https://github.com/user-attachments/assets/bbccebe1-41b9-4be4-9f65-9b952e5190a4)

--- 

**_Also tested cases where the main app does not provide a configuration (apps without the need of including additional routes)._**

**_Everything working as expected._**
